### PR TITLE
Issue6 Add Ability to Delete Products

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -48,6 +48,12 @@ class Product(db.Model):
         db.session.add(self)
         db.session.commit()
 
+    def delete(self):
+        """ Removes a Product from the data store """
+        self.logger.info("Deleting %r", self.name)
+        db.session.delete(self)
+        db.session.commit() 
+
     def serialize(self):
         """ Serializes a Product into a dictionary """
         return {

--- a/service/service.py
+++ b/service/service.py
@@ -101,6 +101,24 @@ def get_products(product_id):
     app.logger.info("Returning product: %s", product.name)
     return make_response(jsonify(product.serialize()), status.HTTP_200_OK)
 
+######################################################################
+# DELETE A PRODUCT
+######################################################################
+
+@app.route("/products/<int:product_id>", methods=["DELETE"])
+
+def delete_products(product_id):
+    """
+    Delete a Product
+    This endpoint will delete a Pet based the id specified in the path
+    """
+    app.logger.info("Request to delete product with id: %s", product_id)
+    product = Product.find(product_id)
+    if product:
+        product.delete()
+
+    app.logger.info("Product with ID [%s] delete complete.", product_id)
+    return make_response("", status.HTTP_204_NO_CONTENT)
 
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -104,6 +104,15 @@ class TestProductModel(unittest.TestCase):
         self.assertEqual(product.category,"Technology")
         self.assertEqual(product.price, 1999.99)
 
+    def test_delete_a_product(self):
+        """ Delete a Product """
+        product = Product(name="iPhone X",description="Black iPhone",category= "Technology", price = 999.99)
+        product.create()
+        self.assertEqual(len(Product.all()), 1)
+        # delete the pet and make sure it isn't in the database
+        product.delete()
+        self.assertEqual(len(Product.all()), 0)
+
 ######################################################################
 #   M A I N
 ######################################################################

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -130,3 +130,17 @@ class TestProductServer(TestCase):
         """ Get a product that's not found """
         resp = self.app.get("/products/0")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_a_product(self):
+        """ Delete a Product """
+        test_product = self._create_products(1)[0]
+        resp = self.app.delete(
+            "/products/{}".format(test_product.id), content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(len(resp.data), 0)
+        # make sure they are deleted
+        resp = self.app.get(
+            "/products/{}".format(test_product.id), content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND) 


### PR DESCRIPTION
1. Updated service.py and models.py to add the feature of deleting product by id.
2. Updated test_models.py and test_service.py to test the deletion of products. 

Below are the nosetest results:

```
Test Cases for Product Model 
- Create a product and add it to the database
- Delete a Product
- Test deserialization of a Product
- Test deserialization of bad data
- Find a Product by ID
- Test serialization of a Product

REST API Server Tests 
- Create a new Product
Invalid Content-Type: text/plain
415 Unsupported Media Type: Content-Type must be application/json
- Create a new Product with invalid content type
404 Not Found: Product with id '2' was not found.
- Delete a Product
- Get a single product by its ID
404 Not Found: Product with id '0' was not found.
- Get a product that's not found
- Test index call

----------------------------------------------------------------------
XML: /vagrant/unittests.xml
Name                  Stmts   Miss  Cover   Missing
---------------------------------------------------
service/__init__.py      25      4    84%   28, 37-40
service/models.py        50      1    98%   81
service/service.py       49      0   100%
---------------------------------------------------
TOTAL                   124      5    96%
----------------------------------------------------------------------
Ran 12 tests in 0.830s

OK


