### PR TITLE
Issue5 Add Ability to Update Products

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -48,6 +48,16 @@ class Product(db.Model):
         db.session.add(self)
         db.session.commit()
 
+    def update(self):
+        """
+        Updates a Product to the data store
+        """
+        self.logger.info("Updating %s", self.name)
+        if not self.id:
+            self.logger.info("Update called with empty ID field")
+            raise DataValidationError("Update called with empty ID field")
+        db.session.commit()
+
     def delete(self):
         """ Removes a Product from the data store """
         self.logger.info("Deleting %r", self.name)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -91,6 +91,32 @@ class TestProductModel(unittest.TestCase):
         products = Product.all()
         self.assertEqual(len(products), 1)
 
+    def test_update_a_product(self):
+        """ Update a Product """
+        product = Product(name="iPhone X",description="Black iPhone",category= "Technology", price = 999.99)
+        product.create()
+        self.assertEqual(product.id, 1)
+        # Change it and update it
+        product.price = 9999.99
+        product.description = "White iPhone"
+        product.update()
+        self.assertEqual(product.id, 1)
+        # Fetch it back and make sure the id hasn't changed
+        # but the data did change
+        products = Product.all()
+        self.assertEqual(len(products), 1)
+        self.assertEqual(products[0].price, 9999.99)
+        self.assertEqual(products[0].description, "White iPhone")
+
+    def test_update_a_product_empty_id(self):
+        """ Update a Product with empty id """
+        product = Product(name="iPhone X",description="Black iPhone",category= "Technology", price = 999.99)
+        product.create()
+        self.assertEqual(product.id, 1)
+        # Change it and update it
+        product.id = None
+        self.assertRaises(DataValidationError, product.update)
+
     def test_find_product(self):
         """ Find a Product by ID """
         Product(name="iPhone X",description="Black iPhone",category= "Technology", price = 999.99).create()
@@ -109,7 +135,7 @@ class TestProductModel(unittest.TestCase):
         product = Product(name="iPhone X",description="Black iPhone",category= "Technology", price = 999.99)
         product.create()
         self.assertEqual(len(Product.all()), 1)
-        # delete the pet and make sure it isn't in the database
+        # delete the product and make sure it isn't in the database
         product.delete()
         self.assertEqual(len(Product.all()), 0)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -144,3 +144,53 @@ class TestProductServer(TestCase):
             "/products/{}".format(test_product.id), content_type="application/json"
         )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND) 
+
+    def test_update_product(self):
+        """ Update an existing Product """
+        # create a product to update
+        test_product = ProductFactory()
+        resp = self.app.post(
+            "/products", json=test_product.serialize(), content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # update the product
+        new_product = resp.get_json()
+        new_product["category"] = "Education"
+        resp = self.app.put(
+            "/products/{}".format(new_product["id"]),
+            json=new_product,
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        updated_product = resp.get_json()
+        self.assertEqual(updated_product["category"], "Education")
+
+    def test_update_product_not_found(self):
+        """ Update a product that's not found """
+        test_product = ProductFactory()
+        resp = self.app.put(
+            "/products/0",
+            json=test_product.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_product_bad_request(self):
+        """ Update a product with bad request body """
+        # create a product to update
+        test_product = ProductFactory()
+        resp = self.app.post(
+            "/products", json=test_product.serialize(), content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # create an update request with bad request body
+        new_product = resp.get_json()
+        new_product.pop("name")
+        resp = self.app.put(
+            "/products/{}".format(new_product["id"]),
+            json=new_product,
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
This pull request resolves issue #5

1. Updated service.py and models.py to support update a product.
2. Updated test_models.py and test_service.py to cover the new functions.
```
Test Cases for Product Model 
- Create a product and add it to the database
- Delete a Product
- Test deserialization of a Product
- Test deserialization of bad data
- Find a Product by ID
- Test serialization of a Product
- Update a Product
- Update a Product with empty id

REST API Server Tests 
- Create a new Product
Invalid Content-Type: text/plain
415 Unsupported Media Type: Content-Type must be application/json
- Create a new Product with invalid content type
404 Not Found: Product with id '2' was not found.
- Delete a Product
- Get a single product by its ID
404 Not Found: Product with id '0' was not found.
- Get a product that's not found
- Test index call
- Update an existing Product
Invalid product : missing name
- Update a product with bad request body
404 Not Found: Product with id '0' was not found.
- Update a product that's not found

----------------------------------------------------------------------
XML: /vagrant/unittests.xml
Name                  Stmts   Miss  Cover   Missing
---------------------------------------------------
service/__init__.py      25      4    84%   28, 37-40
service/models.py        56      0   100%
service/service.py       66      0   100%
---------------------------------------------------
TOTAL                   147      4    97%
----------------------------------------------------------------------
Ran 17 tests in 1.129s

OK
```