### PR TITLE
Issue 67 Add try except for SQL Alchemy Error

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -5,6 +5,7 @@ All of the models are stored in this module
 """
 import logging
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.exc import InvalidRequestError
 
 
 # Create the SQLAlchemy object to be initialized later in init_db()
@@ -46,7 +47,11 @@ class Product(db.Model):
         self.logger.info("Creating %s", self.name)
         self.id = None
         db.session.add(self)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except InvalidRequestError:
+            db.session.rollback()
+        
 
     def update(self):
         """
@@ -56,13 +61,19 @@ class Product(db.Model):
         if not self.id:
             self.logger.info("Update called with empty ID field")
             raise DataValidationError("Update called with empty ID field")
-        db.session.commit()
+        try:
+            db.session.commit()
+        except InvalidRequestError:
+            db.session.rollback()
 
     def delete(self):
         """ Removes a Product from the data store """
         self.logger.info("Deleting %r", self.name)
         db.session.delete(self)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except InvalidRequestError:
+            db.session.rollback()
 
     def serialize(self):
         """ Serializes a Product into a dictionary """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,7 @@ import unittest
 import os
 import json
 from service.models import Product, DataValidationError, db
-from unittest.mock import MagicMock, patch, Mock
+from unittest.mock import MagicMock, patch
 from service import app
 from sqlalchemy.exc import InvalidRequestError
 
@@ -125,6 +125,21 @@ class TestProductModel(unittest.TestCase):
         self.assertEqual(products[0].price, 9999.99)
         self.assertEqual(products[0].description, "White iPhone")
     
+    def test_update_a_product_commit_error(self):
+        """ Update a product and raises an InvalidRequestError """
+        product = Product(name="iPhone X", description="Black iPhone", category="Technology", price=999.99)
+        product.create()
+        self.assertEqual(product.id, 1)
+        # Change it and update it
+        product.price = 9999.99
+        product.description = "White iPhone"
+        with patch('service.models.db.session.commit') as commit:
+            commit.side_effect = InvalidRequestError
+            product.update()
+            products = Product.all()
+            self.assertEqual(len(products), 1)
+            self.assertEqual(products[0].price, 999.99)
+            self.assertEqual(products[0].description, "Black iPhone")
 
     def test_update_a_product_empty_id(self):
         """ Update a Product with empty id """
@@ -196,6 +211,17 @@ class TestProductModel(unittest.TestCase):
         # delete the product and make sure it isn't in the database
         product.delete()
         self.assertEqual(len(Product.all()), 0)
+    
+    def test_delete_a_product_commit_error(self):
+        """ Delete a Product """
+        product = Product(name="iPhone X", description="Black iPhone", category="Technology", price=999.99)
+        product.create()
+        self.assertEqual(len(Product.all()), 1)
+        # delete the product and make sure it isn't in the database
+        with patch('service.models.db.session.commit') as commit:
+            commit.side_effect = InvalidRequestError
+            product.delete()
+            self.assertEqual(len(Product.all()), 1)
 
 ######################################################################
 #   M A I N

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,9 @@ import unittest
 import os
 import json
 from service.models import Product, DataValidationError, db
+from unittest.mock import MagicMock, patch, Mock
 from service import app
+from sqlalchemy.exc import InvalidRequestError
 
 DATABASE_URI = os.getenv("DATABASE_URI", "postgres://postgres:postgres@localhost:5432/postgres")
 
@@ -94,6 +96,18 @@ class TestProductModel(unittest.TestCase):
         products = Product.all()
         self.assertEqual(len(products), 1)
 
+    @patch('service.models.db.session.commit')
+    def test_add_a_product_commit_error(self,commit):
+        """ Create a product and raises an InvalidRequestError """
+        commit.side_effect = InvalidRequestError
+        products = Product.all()
+        self.assertEqual(products, [])
+        product = Product(name="Cake", description="Chocolate Cake", category="Food", price=10.50)
+        self.assertTrue(product is not None)
+        self.assertEqual(product.id, None)
+        product.create()
+        self.assertEqual(products, [])
+
     def test_update_a_product(self):
         """ Update a Product """
         product = Product(name="iPhone X", description="Black iPhone", category="Technology", price=999.99)
@@ -110,6 +124,7 @@ class TestProductModel(unittest.TestCase):
         self.assertEqual(len(products), 1)
         self.assertEqual(products[0].price, 9999.99)
         self.assertEqual(products[0].description, "White iPhone")
+    
 
     def test_update_a_product_empty_id(self):
         """ Update a Product with empty id """


### PR DESCRIPTION
So for this PR I added the try and catch to the `create`,`update`, and `delete` functions in the models.py but I was not able to mock `update`, and `delete`functions for the testing of the models because in the code, we are calling db.commit two times. 

For example, 
```
def test_update_a_product(self):
        """ Update a Product """
        product = Product(name="iPhone X", description="Black iPhone", category="Technology", price=999.99)
        product.create()
        self.assertEqual(product.id, 1)
        # Change it and update it
        product.price = 9999.99
        product.description = "White iPhone"
        product.update()
        self.assertEqual(product.id, 1)
        # Fetch it back and make sure the id hasn't changed
        # but the data did change
        products = Product.all()
        self.assertEqual(len(products), 1)
        self.assertEqual(products[0].price, 9999.99)
        self.assertEqual(products[0].description, "White iPhone")
```
In the function above we are calling the create function which is calling db.commit() and we want that to actually succeed but we want the db.commit in the update function to raise an InvalidRequestError. Sadly, since we want two different responses from the same function, it  impossible to mock. I guess we can only do the test for create then. 
        
**UPDATE**  
I was able to call db.commit two times with two responses using a with clause so we are back at 100%  code coverage 