### PR TITLE
Issue96 Add a threshold value which allow the coverage to drop by 2%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    # pull-requests only
+    patch:
+      default:
+        threshold: 2%


### PR DESCRIPTION
Add .codecov.yml file to set the threshold.

Codecov config is valid:

```
chenmingxideMacBook-Pro:products chenmingxi$ cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
Valid!

{
  "coverage": {
    "status": {
      "patch": {
        "default": {
          "threshold": 2.0
        }
      }
    }
  }
}

```